### PR TITLE
Check output length before retrieving the status

### DIFF
--- a/tasks/recess.js
+++ b/tasks/recess.js
@@ -33,7 +33,7 @@ module.exports = function( grunt ) {
 					min.push( item.output );
 					max.push( item.data );
 				// Extract status and check
-				} else if ( item.output[1].indexOf('Perfect!') !== -1 ) {
+				} else if ( item.output[1] && item.output[1].indexOf('Perfect!') !== -1 ) {
 					grunt.log.writeln( item.output.join( lf ) );
 				} else {
 					grunt.fail.warn( item.output.join( lf ) );


### PR DESCRIPTION
Avoid the task to crash if the output length is < 2 (which is the case when RECESS return a parse error). Should fix issue #13.
