### PR TITLE
Make compatible with grunt 0.4

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,17 +15,15 @@ module.exports = function( grunt ) {
 				]
 			}
 		},
-		lint: {
-			files: [
-				'grunt.js',
-				'tasks/**/*.js'
-			]
-		},
 		watch: {
 			files: '<config:lint.files>',
 			tasks: 'default'
 		},
 		jshint: {
+      lint: [
+        'grunt.js',
+        'tests/**/*.js'
+      ],
 			options: {
 				es5: true,
 				esnext: true,
@@ -47,7 +45,8 @@ module.exports = function( grunt ) {
 	});
 
 	grunt.loadTasks('tasks');
+  grunt.loadNpmTasks('grunt-contrib-jshint');
 
-	grunt.registerTask( 'default', 'lint recess:pass recess:fail' );
+	grunt.registerTask( 'default', ['jshint', 'recess:pass', 'recess:fail'] );
 
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "grunt-recess",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"description": "Lint and minify CSS and LESS",
 	"keywords": [
 		"gruntplugin",
@@ -24,10 +24,12 @@
 		"url": "git://github.com/sindresorhus/grunt-recess.git"
 	},
 	"dependencies": {
-		"recess": "~1.1.6"
+		"recess": "~1.1.6",
+		"grunt-lib-legacyhelpers": "~0.1.x"
 	},
 	"devDependencies": {
-		"grunt": "~0.3.17"
+		"grunt": "~0.4.0",
+		"grunt-contrib-jshint": "~0.1.x"
 	},
 	"engines": {
 		"node": ">=0.8.0"

--- a/tasks/recess.js
+++ b/tasks/recess.js
@@ -1,9 +1,11 @@
+
 module.exports = function( grunt ) {
 	'use strict';
 
 	grunt.registerMultiTask('recess', 'Lint and minify CSS and LESS', function() {
 		var recess = require('recess');
-		var lf = grunt.utils.linefeed;
+    var helpers = require('grunt-lib-legacyhelpers').init(grunt);
+		var lf = grunt.util.linefeed;
 		var cb = this.async();
 		var files = grunt.file.expandFiles( this.file.src );
 		var dest = this.file.dest;
@@ -47,7 +49,7 @@ module.exports = function( grunt ) {
 					grunt.log.writeln( 'File "' + dest + '" created.' );
 
 					if ( compress ) {
-						grunt.helper( 'min_max_info', min.join( separator ), max.join( separator ) );
+						helpers.min_max_info(min.join( separator ), max.join( separator ) );
 					}
 				} else {
 					grunt.fail.fatal('No destination specified. Required when options.compile is enabled.');


### PR DESCRIPTION
Update grunt-recess to work with Grunt 0.4, and bump the version to 0.1.5. Fixes #15.
