### PR TITLE
Bump jshint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "grunt": "~0.4.0",
-    "grunt-contrib-jshint": "~0.1.0"
+    "grunt-contrib-jshint": "~0.1.1"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
Needed to update jshint dependency version to work with grunt 0.4.0rc5
