### PR TITLE
Correct error handling for non-parser errors in recess

### DIFF
--- a/tasks/recess.js
+++ b/tasks/recess.js
@@ -21,8 +21,8 @@ module.exports = function (grunt) {
 			grunt.log.error('Parser error'.red + (err.filename ? ' in ' + err.filename.yellow : '') + '\n');
 		} else {
 			// other exception
-			grunt.log.error(err.name && err.name.red + ': ' + err.message + 
-				(err.filename ? ' of ' + err.filename.yellow : '') + '\n')
+			grunt.log.error((err.name ? err.name.red + ': ' : '') + err.message + 
+				(err.filename ? ' in ' + err.filename.yellow : '') + '\n')
 		}
 
 		// if extract - then log it


### PR DESCRIPTION
I've made the same change for recess and have a pending pull request there as well
