### PR TITLE
Updated Recess to 1.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "recess": "~1.1.6",
+    "recess": "~1.1.7",
     "grunt-lib-contrib": "~0.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Recess 1.1.7 fixed an issue in Recess' dependency having LESS 1.4 beta (that is for Recess 1.1.6) and this resulted in errors:

```
Running "recess:dev" (recess) task
>> TypeError: Cannot call method 'map' of undefined
Warning:  Use --force to continue.
```

More information here: https://github.com/twitter/recess/pull/97
