### PR TITLE
Only report minification statistics on compress

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "recess": "~1.1.6",
-    "grunt-lib-contrib": "~0.5.2"
+    "grunt-lib-contrib": "~0.6.0"
   },
   "devDependencies": {
     "grunt": "~0.4.0",

--- a/tasks/recess.js
+++ b/tasks/recess.js
@@ -87,7 +87,7 @@ module.exports = function (grunt) {
 						grunt.log.writeln('File "' + dest + '" created.');
 
 						if (options.compress) {
-							helpers.minMaxInfo(min.join(separator), max.join(separator));
+							helpers.minMaxInfo(min.join(separator), max.join(separator), 'min');
 						}
 					} else {
 						grunt.fail.fatal('No destination specified. Required when options.compile is enabled.');


### PR DESCRIPTION
grunt-lib-contrib added the capability to disable the gzip report, which significantly speeds up build routines. This PR bumps the dependency to the version in which that feature was added (https://github.com/gruntjs/grunt-lib-contrib/pull/6) and passes the appropriate parameter to disable the gzip report.
