### PR TITLE
Correct package.json license syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,7 @@
   "engines": {
     "node": ">=0.8.0"
   },
-  "licenses": {
-    "type": "MIT"
-  },
+  "license": "MIT",
   "files": [
     "tasks/recess.js"
   ]


### PR DESCRIPTION
There are two formats for package.json license statements:

 "license" : "BSD-3-Clause"

AND

"licenses" : [
  { "type" : "MyLicense"
  , "url" : "http://github.com/owner/project/path/to/license"
  }
]
